### PR TITLE
Correct the docstring of the evaluation script

### DIFF
--- a/src/mcif/evaluation.py
+++ b/src/mcif/evaluation.py
@@ -311,11 +311,9 @@ def main(
 
 def cli_script():
     """
-    Starting from the test set definitions collected in TSV format, this scripts outputs:
-     - IWSLT2025.IF.<track>.<lang>.src.xml: XML files containing the test set definitions to be
-       circulated to participants.
-     - IWSLT2025.IF.<track>.<lang>.ref.xml: XML files containing the corresponding references, to
-       be used to compute the scores.
+    Script that evaluates the outputs of a system in XML format against the MCIF reference.
+    By default, the evaluation is carried out on all the test elements, but the evaluation can be
+    limited to the tasks/samples relevant for one modality by means of the --filter-modality param.
     """
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(


### PR DESCRIPTION
# Motivation

The docstring of the evaluation script was not relevant to it, a leftover from a copy-paste.

# Changes

It replaces the wrong docstring with a relevant one.

# Testing

NA