### PR TITLE
Explicitly set qwen3_omni input processor to with truncation=False

### DIFF
--- a/baselines/models/mllm/qwen3_omni.py
+++ b/baselines/models/mllm/qwen3_omni.py
@@ -96,6 +96,7 @@ def generate(model_processor, prompt, example_path, modality):
         videos=videos,
         return_tensors="pt",
         padding=True,
+        truncation=False,
         use_audio_in_video=USE_AUDIO_IN_VIDEO,
     )
     inputs = inputs.to(model.device).to(model.dtype)


### PR DESCRIPTION
WhisperFeatureExtractor defaults to truncation=True, silently cutting audio longer than 30s. 
Qwen3OmniMoeProcessor (tested at [v4.57.6](https://github.com/huggingface/transformers/releases/tag/v4.57.6)) does not overrides this.

Explicitly passing `truncation=False` makes sure full audio is processed, matching the fix in https://github.com/huggingface/transformers/pull/41473.