### PR TITLE
Fix Qwen3-Omni generate output arguments

### DIFF
--- a/baselines/models/mllm/qwen3_omni.py
+++ b/baselines/models/mllm/qwen3_omni.py
@@ -104,12 +104,17 @@ def generate(model_processor, prompt, example_path, modality):
     # Qwen3-Omni always returns a (text_ids, audio) tuple; with return_audio=False the
     # second element is None. thinker_max_new_tokens/thinker_do_sample are Qwen2.5-Omni
     # specific parameters and are not supported by Qwen3-Omni.
-    text_ids, _ = model.generate(
+    result = model.generate(
         **inputs,
         use_audio_in_video=USE_AUDIO_IN_VIDEO,
         return_audio=False,
         max_new_tokens=4096,
     )
+
+    if isinstance(result, tuple):
+        text_ids = result[0]
+    else:
+        text_ids = result
     text = processor.batch_decode(
         text_ids, skip_special_tokens=True, clean_up_tokenization_spaces=False
     )

--- a/baselines/models/mllm/qwen3_omni.py
+++ b/baselines/models/mllm/qwen3_omni.py
@@ -101,9 +101,6 @@ def generate(model_processor, prompt, example_path, modality):
     )
     inputs = inputs.to(model.device).to(model.dtype)
 
-    # Qwen3-Omni always returns a (text_ids, audio) tuple; with return_audio=False the
-    # second element is None. thinker_max_new_tokens/thinker_do_sample are Qwen2.5-Omni
-    # specific parameters and are not supported by Qwen3-Omni.
     result = model.generate(
         **inputs,
         use_audio_in_video=USE_AUDIO_IN_VIDEO,
@@ -111,6 +108,9 @@ def generate(model_processor, prompt, example_path, modality):
         max_new_tokens=4096,
     )
 
+    # Earlier Qwen3-Omni implementations return a (text_ids, audio) tuple, and, with
+    # return_audio=False the second element is None. However, newer implementations return only a
+    # single element, the text ids.
     if isinstance(result, tuple):
         text_ids = result[0]
     else:


### PR DESCRIPTION
Qwen3-Omni generate in the newer HuggingFace `transformers` versions return only one output argument, while previously, two arguments were returned---(text_ids, audio) tuples. This PR modifies the code to work with both older (e.g., 5.0.0) and newer (e.g., 5.1.16) versions of the code.